### PR TITLE
Go generate fail fixed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /bin/
 /gen/
 /libs/
-/src/go/

--- a/src/go/.gitignore
+++ b/src/go/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all
+*
+# Except gitignore
+!.gitignore


### PR DESCRIPTION
Go generate fails if started against initial repo state.
Fixed by creating empty directory src/go.

Gitignores improved.
